### PR TITLE
Fix apt_key issue from ansible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt: name=apache2 state=absent
 
 - name: Add key for passenger
-  apt_key: url=http://keyserver.ubuntu.com id=AC40B2F7 state=present
+  apt_key: url=http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xAC40B2F7 state=present
   
 - name: Apt via https
   apt: name=apt-transport-https state=present


### PR DESCRIPTION
Your usage of apt_key not works for me and recent ansible ( 1.4.4 ) like report on issue :

https://github.com/ansible/ansible/issues/4810
https://github.com/ansible/ansible/issues/5485

This commit fix it
