### PR TITLE
include support for trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nginx Passenger
 Requirements
 ------------
 
-Ubuntu (10.04, 12.04, 13.10), Debian (6,7) system
+Ubuntu (10.04, 12.04, 13.10, 14.04), Debian (6,7) system
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - trusty
         - saucy
         - precise
         - lucid


### PR DESCRIPTION
as of the 7th May Passenger packages for Ubuntu 14.04 are available [see phusion-passenge blog](http://blog.phusion.nl/2014/05/07/phusion-passenger-4-0-42-released-ubuntu-14-04-packages-available/)
